### PR TITLE
allow prometheus to access app

### DIFF
--- a/docs/ACTIVITY.md
+++ b/docs/ACTIVITY.md
@@ -76,7 +76,7 @@ Created PR: https://github.com/remla24-02/operation/pull/7
 Approved PR: 
 
 -- Arjan Hasami: --  
-Created PR:   
+Created PR: https://github.com/remla24-02/operation/pull/8
 Approved PR: https://github.com/remla24-02/operation/pull/7
 
 -- Nada Mouman: --  

--- a/kubernetes/app.yml
+++ b/kubernetes/app.yml
@@ -39,7 +39,7 @@ spec:
                   name: model-service-config
                   key: model.service.url
             - name: ALLOWED_HOSTS
-              value: app.local
+              value: "app.local,10.1.49.17"
           command: ["python", "manage.py", "runserver", "0.0.0.0:5000"]
           resources:
             limits:
@@ -82,7 +82,7 @@ spec:
                   name: model-service-config
                   key: model.service.url
             - name: ALLOWED_HOSTS
-              value: app.local
+              value: "app.local,10.1.49.17"
           command: ["python", "manage.py", "runserver", "0.0.0.0:5000"]
           resources:
             limits:


### PR DESCRIPTION
- Give Prometheus access to the app by adding "10.1.49.17" to the ALLOWED_HOSTS var
- This allows Prometheus to monitor and log the metrics of the web app